### PR TITLE
feat(ui): enable markdown file attachments

### DIFF
--- a/.agent/workflows/newtask.md
+++ b/.agent/workflows/newtask.md
@@ -1,0 +1,20 @@
+---
+description: work in a new task
+---
+
+New Task,
+
+To get proper context about the project, please read the following files:
+@PRD_GUIDE.md, @BACKEND_GUIDE.md, @FRONTEND_GUIDE.md, @TESTING_GUIDE.md, and @CONVENTIONS.md.
+
+If applicable, please create new unit tests for this change, either on the frontend or the backend. Additionally, if required, create new E2E tests and update @e2e/manual-test-cases-browserstack if any new E2E tests are added.
+
+Also, create a Git branch following the existing branch naming conventions. Create a new branch for this task using the same format and switch to it. The branch should follow the pattern TM-?? (log in to GitHub using the MCP, go to the TaskManager project, find the latest pull request number, and increment it by 1).
+
+Once you finish the implementation:
+Make sure to run the frontend unit tests, backend unit tests, and E2E tests to verify that nothing was broken and to confirm whether any existing tests need to be updated.
+
+In the walkthrough you provide, include the commit message, but do not create the commit yourself. I will create the commit based on the message you provide.
+
+Task to be implemented:
+(The user will describe the task details below.)

--- a/backend/src/middlewares/uploadMiddleware.js
+++ b/backend/src/middlewares/uploadMiddleware.js
@@ -23,7 +23,8 @@ const fileFilter = (req, file, cb) => {
     'application/vnd.openxmlformats-officedocument.presentationml.presentation', // pptx
     'text/csv',
     'audio/mpeg', // mp3
-    'video/mp4'
+    'video/mp4',
+    'text/markdown'
   ];
 
   if (allowedMimes.includes(file.mimetype)) {
@@ -31,12 +32,12 @@ const fileFilter = (req, file, cb) => {
   } else {
     // Check key extensions if mimetype is generic (e.g. application/octet-stream sometimes happens)
     const ext = path.extname(file.originalname).toLowerCase();
-    const allowedExts = ['.jpg', '.jpeg', '.png', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.csv', '.mp3', '.mp4'];
+    const allowedExts = ['.jpg', '.jpeg', '.png', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.csv', '.mp3', '.mp4', '.md'];
     
     if (allowedExts.includes(ext)) {
        cb(null, true);
     } else {
-       cb(new Error('Invalid file type. Allowed types: Word, Excel, PPT, CSV, PNG, JPG, MP3, MP4'), false);
+       cb(new Error('Invalid file type. Allowed types: Word, Excel, PPT, CSV, PNG, JPG, MP3, MP4, Markdown'), false);
     }
   }
 };

--- a/backend/src/tests/routes/upload.test.js
+++ b/backend/src/tests/routes/upload.test.js
@@ -77,6 +77,14 @@ describe('Upload Middleware via Routes', () => {
         expect(res.statusCode).toBe(201);
     });
 
+    it('should allow valid markdown file', async () => {
+        const res = await request(appWithHandler)
+            .post('/api/upload')
+            .attach('file', Buffer.from('# Markdown'), 'readme.md');
+        
+        expect(res.statusCode).toBe(201);
+    });
+
     it('should reject invalid file extension', async () => {
         const res = await request(appWithHandler)
             .post('/api/upload')

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -56,7 +56,7 @@ Utilizamos **Conventional Commits** con el siguiente formato:
 
 #### ✅ Hacer:
 - Usar imperativo presente: "add" no "added" o "adds"
-- Primera letra en minúscula
+- Primera letra en minúscula (Todo el asunto debe ser en minúscula para pasar el linter)
 - No terminar con punto
 - Ser descriptivo pero conciso (máximo 72 caracteres en el título)
 - Usar inglés para consistencia

--- a/e2e/manual-test-cases-browserstack/tasks.csv
+++ b/e2e/manual-test-cases-browserstack/tasks.csv
@@ -48,3 +48,7 @@ Title,Description,Preconditions,Steps,Expected Result,Priority,Type,Tags,Automat
 "AI - Error UI","Verify premium in-app error feedback","User is logged in","Open AI Assistant with empty description.","AI Options visible.","Medium","Functional","Tasks,AI,UI","Automated"
 "AI - Error UI","","","Click 'Improve Grammar'.","In-app red error card is visible with message 'Please enter a description first.'","Medium","Functional","Tasks,AI,UI","Automated"
 "AI - Error UI","","","Click 'X' on error card.","Error card disappears.","Medium","Functional","Tasks,AI,UI","Automated"
+"Attachments - Markdown Upload","Verify markdown .md file attachment","User is logged in","Open Add Task Modal.","Modal opens.","High","Functional","Tasks,Upload","Automated"
+"Attachments - Markdown Upload","","","Attach a .md file.","Upload success indicator visible.","High","Functional","Tasks,Upload","Automated"
+"Attachments - Markdown Upload","","","Save task.","Task created with attachment.","High","Functional","Tasks,Upload","Automated"
+"Attachments - Markdown Upload","","","Open Task Detail.","Attachment listed with View/Download options.","High","Functional","Tasks,Upload","Automated"

--- a/src/components/FileUploader.tsx
+++ b/src/components/FileUploader.tsx
@@ -106,7 +106,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
           className="hidden"
           onChange={handleFileSelect}
           // Accept commonly used types
-          accept=".doc,.docx,.xls,.xlsx,.ppt,.pptx,.csv,image/*,.mp3,.mp4"
+          accept=".doc,.docx,.xls,.xlsx,.ppt,.pptx,.csv,image/*,.mp3,.mp4,.md"
         />
 
         {isUploading ? (

--- a/src/test/components/FileUploader.test.tsx
+++ b/src/test/components/FileUploader.test.tsx
@@ -65,6 +65,27 @@ describe('FileUploader', () => {
     });
   });
 
+  it('handles markdown file selection', async () => {
+    const user = userEvent.setup();
+    const { container } = renderWithTheme(<FileUploader onUploadComplete={mockOnUploadComplete} />);
+    
+    const file = new File(['# Markdown Content'], 'readme.md', { type: 'text/markdown' });
+    const hiddenInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    
+    expect(hiddenInput).toBeInTheDocument();
+    expect(hiddenInput.accept).toContain('.md');
+
+    await user.upload(hiddenInput, file);
+
+    await waitFor(() => {
+        expect(taskService.uploadFile).toHaveBeenCalledWith(file);
+    });
+    
+    await waitFor(() => {
+         expect(mockOnUploadComplete).toHaveBeenCalled();
+    });
+  });
+
   it('displays error logic (passed via prop)', async () => {
     const { container } = renderWithTheme(<FileUploader onUploadComplete={mockOnUploadComplete} onError={mockOnError} />);
     


### PR DESCRIPTION
## Description
Enabled support for uploading and attaching markdown (.md) files to tasks.
Includes changes to frontend FileUploader and backend uploadMiddleware.

## Changes
- Frontend: Accept .md files in FileUploader
- Backend: Allow text/markdown mimetype and .md extension
- Tests: Added unit tests and E2E coverage for markdown uploads