### PR TITLE
feat: restrict task editing to authenticated users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from './contexts/AuthContext';
 import HelpFAB from './components/features/help/HelpFAB';
 import { Toaster } from 'sonner';
+import { AuthRequiredModal } from './components/features/auth/AuthRequiredModal';
 
 const MainApp = () => {
   const {
@@ -100,6 +101,9 @@ const MainApp = () => {
   const [isErrorModalOpen, setIsErrorModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
 
+  // Auth Required Modal State
+  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+
   const handleTaskClick = (taskId: string) => {
     setSelectedTaskId(taskId);
     setIsDetailModalOpen(true);
@@ -149,6 +153,10 @@ const MainApp = () => {
   };
 
   const handleEditTask = (task: Task) => {
+    if (!isAuthenticated) {
+      setIsAuthModalOpen(true);
+      return;
+    }
     setEditingTask(task);
     setIsFormOpen(true);
   };
@@ -798,10 +806,15 @@ const MainApp = () => {
         isOpen={isDetailModalOpen}
         onClose={handleCloseDetailModal}
         onEdit={(task) => {
-          handleCloseDetailModal();
           handleEditTask(task);
+          handleCloseDetailModal();
         }}
         getElapsedTime={getElapsedTime}
+      />
+
+      <AuthRequiredModal
+        isOpen={isAuthModalOpen}
+        onClose={() => setIsAuthModalOpen(false)}
       />
 
       {/* Error Modal */}

--- a/src/components/features/auth/AuthRequiredModal.tsx
+++ b/src/components/features/auth/AuthRequiredModal.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { useTheme } from '../../../contexts/ThemeContext';
+import { X, Lock, LogIn } from 'lucide-react';
+
+interface AuthRequiredModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+export const AuthRequiredModal: React.FC<AuthRequiredModalProps> = ({
+    isOpen,
+    onClose,
+}) => {
+    const { t } = useTranslation();
+    const { theme } = useTheme();
+    const navigate = useNavigate();
+    const [isAnimating, setIsAnimating] = useState(false);
+
+    useEffect(() => {
+        if (isOpen) {
+            setIsAnimating(true);
+        }
+    }, [isOpen]);
+
+    if (!isOpen) return null;
+
+    const handleClose = () => {
+        setIsAnimating(false);
+        setTimeout(onClose, 300);
+    };
+
+    const handleLogin = () => {
+        setIsAnimating(false);
+        setTimeout(() => {
+            onClose();
+            navigate('/login');
+        }, 300);
+    };
+
+    return (
+        <div
+            className={`fixed inset-0 z-[60] flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm transition-opacity duration-300 ${isAnimating ? 'opacity-100' : 'opacity-0'}`}
+            data-testid="auth-required-modal-overlay"
+        >
+            <div
+                className={`relative w-full max-w-sm rounded-2xl shadow-2xl transform transition-all duration-300 ${isAnimating ? 'scale-100 translate-y-0' : 'scale-95 translate-y-4'
+                    } ${theme === 'dark'
+                        ? 'bg-gray-900 border border-gray-800 text-gray-100'
+                        : 'bg-white text-gray-900'
+                    }`}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="auth-modal-title"
+                data-testid="auth-required-modal"
+            >
+                {/* Decorative top bar */}
+                <div className={`h-1.5 w-full rounded-t-2xl ${theme === 'dark' ? 'bg-indigo-500' : 'bg-indigo-600'}`} />
+
+                <div className="p-8">
+                    <button
+                        onClick={handleClose}
+                        className={`absolute top-4 right-4 p-2 rounded-full transition-colors duration-200 ${theme === 'dark'
+                            ? 'hover:bg-gray-800 text-gray-500 hover:text-gray-300'
+                            : 'hover:bg-gray-100 text-gray-400 hover:text-gray-600'
+                            }`}
+                        aria-label="Close modal"
+                        data-testid="auth-modal-close-button"
+                    >
+                        <X size={18} />
+                    </button>
+
+                    <div className="flex flex-col items-center text-center space-y-4">
+                        <div className={`p-4 rounded-2xl ${theme === 'dark' ? 'bg-indigo-500/10 text-indigo-400' : 'bg-indigo-50 text-indigo-600'
+                            }`}>
+                            <Lock size={32} className="animate-pulse" data-testid="auth-modal-icon" />
+                        </div>
+
+                        <div className="space-y-2">
+                            <h2
+                                id="auth-modal-title"
+                                className="text-2xl font-extrabold tracking-tight"
+                                data-testid="auth-modal-title"
+                            >
+                                {t('auth.auth_required_title')}
+                            </h2>
+                            <p
+                                className={`text-base font-medium ${theme === 'dark' ? 'text-gray-400' : 'text-gray-600'}`}
+                                data-testid="auth-modal-message"
+                            >
+                                {t('auth.auth_required_message')}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div className="mt-8 space-y-3">
+                        <button
+                            onClick={handleLogin}
+                            className={`w-full flex items-center justify-center gap-3 py-3.5 px-4 rounded-xl font-bold transition-all duration-200 active:scale-95 ${theme === 'dark'
+                                ? 'bg-indigo-500 hover:bg-indigo-400 text-white shadow-lg shadow-indigo-500/20'
+                                : 'bg-indigo-600 hover:bg-indigo-700 text-white shadow-lg shadow-indigo-600/20'
+                                }`}
+                            data-testid="auth-modal-login-button"
+                        >
+                            <LogIn size={18} />
+                            {t('auth.login')}
+                        </button>
+
+                        <button
+                            onClick={handleClose}
+                            className={`w-full py-3 px-4 rounded-xl font-medium transition-all duration-200 ${theme === 'dark'
+                                ? 'text-gray-400 hover:text-gray-200 hover:bg-gray-800'
+                                : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                                }`}
+                            data-testid="auth-modal-cancel-button"
+                        >
+                            {t('common.cancel')}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,6 +27,8 @@
         "invalid_email": "Invalid email format",
         "go_to_login": "Go to Login",
         "email_not_confirmed": "Email not confirmed",
+        "auth_required_title": "Authentication Required",
+        "auth_required_message": "To edit tasks, you need to sign in to your account.",
         "join_us": "Join us to manage your tasks efficiently",
         "login_google": "LOG IN WITH GOOGLE",
         "signup_google": "SIGN UP WITH GOOGLE",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -33,7 +33,9 @@
         "go_to_login": "Ir a Iniciar Sesión",
         "github_error": "Error al iniciar sesión con GitHub",
         "invalid_email": "Formato de correo inválido",
-        "email_not_confirmed": "Correo electrónico no confirmado"
+        "email_not_confirmed": "Correo electrónico no confirmado",
+        "auth_required_title": "Autenticación requerida",
+        "auth_required_message": "Para editar tareas, necesitas iniciar sesión en tu cuenta."
     },
     "stats_view": {
         "title": "Estadísticas de Tiempo",


### PR DESCRIPTION
### Objective
Restrict the "Edit" capability to authenticated users only. Unauthenticated users are now prompted with a login reminder modal when attempting to edit a task.

### Changes
- **AuthRequiredModal**: Created a new feature component `AuthRequiredModal.tsx` to handle authentication prompting.
- **Handler Protection**: Wrapped `handleEditTask` in `App.tsx` with an `isAuthenticated` check.
- **Localization**: Added English and Spanish translations for the new modal.

### Verification
- Verified that "New Task" registration and "Status Changes" (Kanban drag-and-drop) remain public as requested.
- Verified the `AuthRequiredModal` correctly triggers from both task card icons and the task detail modal when unauthenticated.
- Verified successful redirection to `/login` via the modal action button.

![Verification Flow](file:///Users/kelvincalcano/.gemini/antigravity/brain/3d740a7a-0fe1-480c-9475-089076ba9c5a/verify_refined_auth_1770102926638.webp)