### PR TITLE
Fix: Prevent intermittent 500 errors on POST /api/tasks by validating estimation

### DIFF
--- a/backend/src/tests/controllers/taskController.test.js
+++ b/backend/src/tests/controllers/taskController.test.js
@@ -136,6 +136,21 @@ describe('Task Controller', () => {
       });
     });
 
+    it('should return 400 if estimation is invalid', async () => {
+      req.body = {
+        title: 'Test Task',
+        estimation: 4
+      };
+
+      await createTask(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Validation error',
+        message: 'Invalid estimation. Must be one of: 1, 2, 3, 5, 8, 13'
+      });
+    });
+
     it('should return 404 if parent task does not exist', async () => {
       req.body = {
         title: 'Test Task',
@@ -158,6 +173,26 @@ describe('Task Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         error: 'Not found',
         message: 'Parent task not found or does not belong to you'
+      });
+    });
+
+    it('should map check violations to 400 on create', async () => {
+      req.body = { title: 'Test Task', estimation: 5 };
+
+      const mockInsert = jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: null, error: { code: '23514', message: 'new row violates check constraint' } })
+        })
+      });
+
+      supabase.from.mockReturnValue({ insert: mockInsert });
+
+      await createTask(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Validation error',
+        message: 'new row violates check constraint'
       });
     });
 
@@ -425,6 +460,27 @@ describe('Task Controller', () => {
         estimation: 8,
         responsible: 'Alice'
       }));
+    });
+
+    it('should return 400 if estimation is invalid on update', async () => {
+      req.params.id = '1';
+      req.body = { estimation: 4 };
+
+      const existingTask = { id: 1, title: 'Task', user_id: 'user-123' };
+      const mockSingle = jest.fn().mockResolvedValue({ data: existingTask, error: null });
+      const mockEqUser = jest.fn().mockReturnValue({ single: mockSingle });
+      const mockEq = jest.fn().mockReturnValue({ eq: mockEqUser });
+      const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+
+      supabase.from.mockReturnValue({ select: mockSelect });
+
+      await updateTask(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Validation error',
+        message: 'Invalid estimation. Must be one of: 1, 2, 3, 5, 8, 13'
+      });
     });
 
     it('should return 400 if no fields to update', async () => {

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -218,7 +218,7 @@ Create a new task.
 ```
 
 **Error Responses:**
-- `400`: Missing title, invalid status, parent task not found
+- `400`: Missing title, invalid status, invalid estimation (must be one of `1,2,3,5,8,13`), parent task not found
 - `401`: Not authenticated
 - `500`: Internal server error
 
@@ -281,7 +281,7 @@ Update an existing task.
 ```
 
 **Error Responses:**
-- `400`: No fields to update, invalid status, task cannot be its own parent, invalid task ID
+- `400`: No fields to update, invalid status, invalid estimation (must be one of `1,2,3,5,8,13`), task cannot be its own parent, invalid task ID
 - `401`: Not authenticated
 - `404`: Task not found or doesn't belong to user
 - `500`: Internal server error

--- a/docs/BACKEND_GUIDE.md
+++ b/docs/BACKEND_GUIDE.md
@@ -224,7 +224,7 @@ Handles authentication logic with:
 #### taskController.js
 Manages task CRUD operations with:
 - **User Isolation**: All operations automatically scoped to authenticated user
-- **Input Validation**: Title required, status validation, parent task verification, estimation & responsible sanitization
+- **Input Validation**: Title required, status validation, parent task verification, estimation validation (`1,2,3,5,8,13`) and responsible sanitization. DB check/constraint errors are mapped to `400` when applicable.
 - **CRUD Operations**:
   - `createTask`: Create new task with user ownership
   - `getTasks`: Retrieve user's tasks with optional status filter


### PR DESCRIPTION
﻿## Summary
This PR addresses intermittent `500 Failed to create task` responses observed on `POST /api/tasks`.

### Root cause
The API accepted unsupported `estimation` values (e.g., `4`, `6`, `7`) and relied on DB CHECK constraints to reject them. Those DB errors were bubbling up as generic `500` responses.

### What changed
- Added explicit estimation validation in task create/update handlers.
  - Allowed values: `1, 2, 3, 5, 8, 13`
- Added DB error mapping for known validation/constraint errors (`23514`, `22P02`, `23502`) to return `400 Validation error` instead of generic `500`.
- Kept generic `500` handling for unexpected errors.

## Tests
- Added/updated controller tests for:
  - invalid estimation on create
  - invalid estimation on update
  - DB check violation mapped to `400`
- Verified backend controller suite passes.

## Docs
- Updated `docs/API_DOCS.md`
- Updated `docs/BACKEND_GUIDE.md`
- Added issue entry in `docs/ISSUES_FIXED.md`

## Impact
- Better API reliability and predictable error semantics.
- Easier debugging for clients and agents that create tasks programmatically.
