### PR TITLE
chore: remove unused TaskService/UserProfile exports flagged by react-doctor

### DIFF
--- a/src/contexts/UserProfileContext.tsx
+++ b/src/contexts/UserProfileContext.tsx
@@ -3,7 +3,7 @@ import { useAuth } from './AuthContext';
 import supabase from '../lib/supabaseClient';
 import { API_BASE_URL } from '../utils/apiConfig';
 
-export interface UserProfile {
+interface UserProfile {
     id: string;
     username: string;
     display_name: string | null;

--- a/src/services/taskService.ts
+++ b/src/services/taskService.ts
@@ -61,7 +61,7 @@ interface BackendComment {
 /**
  * Service for managing tasks through the backend API
  */
-export class TaskService {
+class TaskService {
   private baseUrl: string;
 
   constructor() {


### PR DESCRIPTION
## Summary
This PR fixes the two react-doctor warnings shown in your screenshot:

- `Unused export: TaskService`
- `Unused type: UserProfile`

### Changes
- `src/services/taskService.ts`
  - changed `export class TaskService` -> `class TaskService`
  - keeps `export const taskService = new TaskService()` as the public API

- `src/contexts/UserProfileContext.tsx`
  - changed `export interface UserProfile` -> `interface UserProfile`
  - interface remains used internally by the context typing

## Validation
- `npx vitest run src/test/hooks/useUserProfile.test.tsx src/test/pages/ResetPasswordPage.test.tsx`
- tests passed (14/14)
