### PR TITLE
chore: clean react-doctor unused export/type findings

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
 export const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-export const supabaseAnonKey = import.meta.env.VITE_SUPABASE_KEY;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_KEY;
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Supabase URL and Anon Key must be defined in .env file with VITE_ prefix');

--- a/src/types/Task.ts
+++ b/src/types/Task.ts
@@ -39,20 +39,6 @@ export interface TaskFilter {
   searchTerm?: string;
 }
 
-export interface ImportedTaskRow {
-  id?: string;
-  title: string;
-  description?: string;
-  status: string;
-  createdAt: string;
-  dueDate?: string;
-  parentId?: string;
-  childIds?: string;
-  // Time tracking fields
-  totalTimeSpent?: string;
-  timeEntries?: string;
-}
-
 export interface TaskTimeStats {
   id: string;
   title: string;


### PR DESCRIPTION
## Summary
Follow-up cleanup after PR #71 merge to address remaining `react-doctor` findings:

- remove unused export `supabaseAnonKey` from `src/lib/supabaseClient.ts`
- remove dead type `ImportedTaskRow` from `src/types/Task.ts`

## Validation
- `npx tsc --noEmit`
- `npx -y react-doctor@latest`
  - Result: **No issues found (100/100)**
