### PR TITLE
fix(auth): hoist mobile logo component

### DIFF
--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -51,6 +51,16 @@ const LeftSideImage: React.FC = () => (
   </div>
 );
 
+const MobileLogo = () => (
+  <div className="flex justify-center mb-8 lg:hidden">
+    <div data-testid="app-logo-mobile" className="font-bold text-indigo-600 dark:text-indigo-400 text-3xl mobile-logo-animation light dark:dark">
+      {'Kolium'.split('').map((letter, index) => (
+        <span key={index}>{letter}</span>
+      ))}
+    </div>
+  </div>
+);
+
 const ResetPasswordPage: React.FC = () => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -159,15 +169,6 @@ const ResetPasswordPage: React.FC = () => {
     }
   };
 
-  const MobileLogo = () => (
-    <div className="flex justify-center mb-8 lg:hidden">
-      <div data-testid="app-logo-mobile" className="font-bold text-indigo-600 dark:text-indigo-400 text-3xl mobile-logo-animation light dark:dark">
-        {'Kolium'.split('').map((letter, index) => (
-          <span key={index}>{letter}</span>
-        ))}
-      </div>
-    </div>
-  );
 
   // Show loading screen while validating session
   if (isValidatingSession) {


### PR DESCRIPTION
## Summary
- moved mobile logo to module scope outside of reset password page
- resolves react-doctor warning about nested component definition
- prevents new component instance creation on every render