### PR TITLE
fix: switch framer-motion usage to LazyMotion + m

### DIFF
--- a/src/components/blocks/pricing.test.tsx
+++ b/src/components/blocks/pricing.test.tsx
@@ -9,7 +9,7 @@ vi.mock('canvas-confetti', () => ({
 
 vi.mock('framer-motion', () => ({
   LazyMotion: ({ children }: any) => <>{children}</>,
-  domAnimation: {},
+  domAnimation: { type: 'domAnimation' },
   m: {
     div: ({ children, className, onClick }: any) => (
       <div className={className} onClick={onClick}>

--- a/src/components/blocks/pricing.test.tsx
+++ b/src/components/blocks/pricing.test.tsx
@@ -8,7 +8,9 @@ vi.mock('canvas-confetti', () => ({
 }));
 
 vi.mock('framer-motion', () => ({
-  motion: {
+  LazyMotion: ({ children }: any) => <>{children}</>,
+  domAnimation: {},
+  m: {
     div: ({ children, className, onClick }: any) => (
       <div className={className} onClick={onClick}>
         {children}

--- a/src/components/blocks/pricing.tsx
+++ b/src/components/blocks/pricing.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Check } from "lucide-react"
-import { motion } from "framer-motion"
+import { LazyMotion, domAnimation, m } from "framer-motion"
 import confetti from "canvas-confetti"
 import NumberFlow from "@number-flow/react"
 import { Button } from "../ui/button"
@@ -133,6 +133,7 @@ export function Pricing({
   }
 
   return (
+    <LazyMotion features={domAnimation}>
     <div className="py-10 sm:py-16">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
@@ -160,7 +161,7 @@ export function Pricing({
 
         <div className="mx-auto mt-8 grid max-w-lg grid-cols-1 gap-y-6 sm:mt-12 sm:gap-y-0 lg:max-w-7xl lg:grid-cols-3 lg:gap-x-8">
           {plans.map((plan, planIdx) => (
-            <motion.div
+            <m.div
               key={plan.id}
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
@@ -229,10 +230,12 @@ export function Pricing({
                       ? t('pricing.start_free_trial', 'Start Free Trial')
                       : t('pricing.get_started', 'Get Started')))}
               </Button>
-            </motion.div>
+            </m.div>
           ))}
         </div>
       </div>
     </div>
+    </LazyMotion>
   )
 }
+

--- a/src/components/blocks/pricing.tsx
+++ b/src/components/blocks/pricing.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { Check } from "lucide-react"
-import { LazyMotion, domAnimation, m } from "framer-motion"
+import { m } from "framer-motion"
 import confetti from "canvas-confetti"
 import NumberFlow from "@number-flow/react"
 import { Button } from "../ui/button"
@@ -133,8 +133,7 @@ export function Pricing({
   }
 
   return (
-    <LazyMotion features={domAnimation}>
-    <div className="py-10 sm:py-16">
+        <div className="py-10 sm:py-16">
       <div className="mx-auto max-w-7xl px-6 lg:px-8">
         <div className="mx-auto max-w-2xl text-center">
           <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
@@ -235,7 +234,7 @@ export function Pricing({
         </div>
       </div>
     </div>
-    </LazyMotion>
   )
 }
+
 

--- a/src/components/ui/hover-border-gradient.tsx
+++ b/src/components/ui/hover-border-gradient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
-import { motion } from "framer-motion";
+import { LazyMotion, domAnimation, m } from "framer-motion";
 import { cn } from "../../lib/utils";
 
 type Direction = "TOP" | "LEFT" | "BOTTOM" | "RIGHT";
@@ -59,6 +59,7 @@ export function HoverBorderGradient({
   }, [hovered, duration, clockwise]);
 
   return (
+    <LazyMotion features={domAnimation}>
     <Tag
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
@@ -76,7 +77,7 @@ export function HoverBorderGradient({
       >
         {children}
       </div>
-      <motion.div
+      <m.div
         className={cn(
           "flex-none inset-0 overflow-hidden absolute z-0 rounded-[inherit]"
         )}
@@ -96,5 +97,7 @@ export function HoverBorderGradient({
       />
       <div className="bg-black absolute z-1 flex-none inset-[2px] rounded-[inherit]" />
     </Tag>
+    </LazyMotion>
   );
 }
+

--- a/src/components/ui/hover-border-gradient.tsx
+++ b/src/components/ui/hover-border-gradient.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState, useEffect } from "react";
-import { LazyMotion, domAnimation, m } from "framer-motion";
+import { m } from "framer-motion";
 import { cn } from "../../lib/utils";
 
 type Direction = "TOP" | "LEFT" | "BOTTOM" | "RIGHT";
@@ -59,8 +59,7 @@ export function HoverBorderGradient({
   }, [hovered, duration, clockwise]);
 
   return (
-    <LazyMotion features={domAnimation}>
-    <Tag
+        <Tag
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       className={cn(
@@ -97,7 +96,7 @@ export function HoverBorderGradient({
       />
       <div className="bg-black absolute z-1 flex-none inset-[2px] rounded-[inherit]" />
     </Tag>
-    </LazyMotion>
   );
 }
+
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,16 +5,18 @@ import './index.css';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { AuthProvider } from './contexts/AuthContext';
 import { UserProfileProvider } from './contexts/UserProfileContext';
-import { MotionConfig } from 'framer-motion';
+import { LazyMotion, MotionConfig, domAnimation } from 'framer-motion';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AuthProvider>
       <UserProfileProvider>
         <ThemeProvider>
-          <MotionConfig reducedMotion='user'>
-            <App />
-          </MotionConfig>
+          <LazyMotion features={domAnimation}>
+            <MotionConfig reducedMotion='user'>
+              <App />
+            </MotionConfig>
+          </LazyMotion>
         </ThemeProvider>
       </UserProfileProvider>
     </AuthProvider>

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -7,7 +7,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { motion } from 'framer-motion';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 
 const ForgotPasswordPage: React.FC = () => {
   const { t } = useTranslation();
@@ -40,6 +40,7 @@ const ForgotPasswordPage: React.FC = () => {
 
   if (isEmailSent) {
     return (
+      <LazyMotion features={domAnimation}>
       <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
         {/* Left side - Decorative Image (Desktop only) - 50% width */}
         <div className="hidden lg:flex lg:w-1/2 relative bg-indigo-600 dark:bg-indigo-900 overflow-hidden">
@@ -53,7 +54,7 @@ const ForgotPasswordPage: React.FC = () => {
           </div>
 
           {/* Illustrations - video backgrounds for performance */}
-          <motion.div 
+          <m.div 
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 1 }}
@@ -77,7 +78,7 @@ const ForgotPasswordPage: React.FC = () => {
               playsInline
               className="hidden dark:block w-full h-full object-cover object-left opacity-80 transition-all duration-500"
             />
-          </motion.div>
+          </m.div>
 
           {/* Subtle overlay */}
           <div className="absolute inset-0 bg-gradient-to-tr from-indigo-900/20 to-transparent pointer-events-none"></div>
@@ -132,10 +133,12 @@ const ForgotPasswordPage: React.FC = () => {
           </div>
         </div>
       </div>
+      </LazyMotion>
     );
   }
 
   return (
+    <LazyMotion features={domAnimation}>
     <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
       {/* Left side - Decorative Image (Desktop only) - 50% width */}
       <div className="hidden lg:flex lg:w-1/2 relative bg-indigo-600 dark:bg-indigo-900 overflow-hidden">
@@ -149,7 +152,7 @@ const ForgotPasswordPage: React.FC = () => {
         </div>
 
         {/* Illustrations - video backgrounds for performance */}
-        <motion.div 
+        <m.div 
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 1 }}
@@ -173,7 +176,7 @@ const ForgotPasswordPage: React.FC = () => {
             playsInline
             className="hidden dark:block w-full h-full object-cover object-left opacity-80 transition-all duration-500"
           />
-        </motion.div>
+        </m.div>
 
         {/* Subtle overlay */}
         <div className="absolute inset-0 bg-gradient-to-tr from-indigo-900/20 to-transparent pointer-events-none"></div>
@@ -253,6 +256,7 @@ const ForgotPasswordPage: React.FC = () => {
         </div>
       </div>
     </div>
+    </LazyMotion>
   );
 };
 

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -7,7 +7,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { LazyMotion, domAnimation, m } from 'framer-motion';
+import { m } from 'framer-motion';
 
 const ForgotPasswordPage: React.FC = () => {
   const { t } = useTranslation();
@@ -40,8 +40,7 @@ const ForgotPasswordPage: React.FC = () => {
 
   if (isEmailSent) {
     return (
-      <LazyMotion features={domAnimation}>
-      <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
+            <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
         {/* Left side - Decorative Image (Desktop only) - 50% width */}
         <div className="hidden lg:flex lg:w-1/2 relative bg-indigo-600 dark:bg-indigo-900 overflow-hidden">
           {/* Logo context in the image side - Top Left over image */}
@@ -133,13 +132,11 @@ const ForgotPasswordPage: React.FC = () => {
           </div>
         </div>
       </div>
-      </LazyMotion>
     );
   }
 
   return (
-    <LazyMotion features={domAnimation}>
-    <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
+        <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
       {/* Left side - Decorative Image (Desktop only) - 50% width */}
       <div className="hidden lg:flex lg:w-1/2 relative bg-indigo-600 dark:bg-indigo-900 overflow-hidden">
         {/* Logo context in the image side - Top Left over image */}
@@ -256,8 +253,8 @@ const ForgotPasswordPage: React.FC = () => {
         </div>
       </div>
     </div>
-    </LazyMotion>
   );
 };
 
 export default ForgotPasswordPage;
+

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -8,7 +8,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { motion } from 'framer-motion';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 
 const LoginPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -87,6 +87,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
+    <LazyMotion features={domAnimation}>
     <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden relative">
       <div className="absolute top-4 right-4 z-50">
         <LanguageToggle />
@@ -103,7 +104,7 @@ const LoginPage: React.FC = () => {
         </div>
 
         {/* Illustrations - video backgrounds for performance */}
-        <motion.div 
+        <m.div 
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 1 }}
@@ -127,7 +128,7 @@ const LoginPage: React.FC = () => {
             playsInline
             className="hidden dark:block w-full h-full object-cover object-left opacity-80 transition-all duration-500"
           />
-        </motion.div>
+        </m.div>
 
         {/* Subtle overlay */}
         <div className="absolute inset-0 bg-gradient-to-tr from-indigo-900/20 to-transparent pointer-events-none"></div>
@@ -175,7 +176,9 @@ const LoginPage: React.FC = () => {
         </div>
       </div>
     </div>
+    </LazyMotion>
   );
 };
 
 export default LoginPage;
+

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -8,7 +8,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { LazyMotion, domAnimation, m } from 'framer-motion';
+import { m } from 'framer-motion';
 
 const LoginPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -87,8 +87,7 @@ const LoginPage: React.FC = () => {
   };
 
   return (
-    <LazyMotion features={domAnimation}>
-    <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden relative">
+        <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden relative">
       <div className="absolute top-4 right-4 z-50">
         <LanguageToggle />
       </div>
@@ -176,9 +175,9 @@ const LoginPage: React.FC = () => {
         </div>
       </div>
     </div>
-    </LazyMotion>
   );
 };
 
 export default LoginPage;
+
 

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -9,7 +9,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { LazyMotion, domAnimation, m } from 'framer-motion';
+import { m } from 'framer-motion';
 
 const RegisterPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -100,8 +100,7 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
-    <LazyMotion features={domAnimation}>
-    <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden relative">
+        <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden relative">
       <div className="absolute top-4 right-4 z-50">
         <LanguageToggle />
       </div>
@@ -194,10 +193,10 @@ const RegisterPage: React.FC = () => {
         </div>
       </div>
     </div>
-    </LazyMotion>
   );
 };
 
 
 export default RegisterPage;
+
 

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -9,7 +9,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { motion } from 'framer-motion';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 
 const RegisterPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -100,6 +100,7 @@ const RegisterPage: React.FC = () => {
   };
 
   return (
+    <LazyMotion features={domAnimation}>
     <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden relative">
       <div className="absolute top-4 right-4 z-50">
         <LanguageToggle />
@@ -123,7 +124,7 @@ const RegisterPage: React.FC = () => {
         </div>
 
         {/* Illustrations - video backgrounds for performance */}
-        <motion.div 
+        <m.div 
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 1 }}
@@ -147,7 +148,7 @@ const RegisterPage: React.FC = () => {
             playsInline
             className="hidden dark:block w-full h-full object-cover object-left opacity-80 transition-all duration-500"
           />
-        </motion.div>
+        </m.div>
 
         {/* Subtle overlay */}
         <div className="absolute inset-0 bg-gradient-to-tr from-indigo-900/20 to-transparent pointer-events-none"></div>
@@ -193,8 +194,10 @@ const RegisterPage: React.FC = () => {
         </div>
       </div>
     </div>
+    </LazyMotion>
   );
 };
 
 
 export default RegisterPage;
+

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -6,7 +6,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { motion } from 'framer-motion';
+import { LazyMotion, domAnimation, m } from 'framer-motion';
 
 const ResetPasswordPage: React.FC = () => {
   const [password, setPassword] = useState('');
@@ -128,7 +128,7 @@ const ResetPasswordPage: React.FC = () => {
         </div>
 
         {/* Illustrations - video backgrounds for performance */}
-        <motion.div 
+        <m.div 
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ duration: 1 }}
@@ -152,7 +152,7 @@ const ResetPasswordPage: React.FC = () => {
             playsInline
             className="hidden dark:block w-full h-full object-cover object-left opacity-80 transition-all duration-500"
           />
-        </motion.div>
+        </m.div>
         
         {/* Subtle overlay */}
         <div className="absolute inset-0 bg-gradient-to-tr from-indigo-900/20 to-transparent pointer-events-none"></div>
@@ -172,6 +172,7 @@ const ResetPasswordPage: React.FC = () => {
   // Show loading screen while validating session
   if (isValidatingSession) {
     return (
+      <LazyMotion features={domAnimation}>
       <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
         <LeftSideImage />
 
@@ -190,11 +191,13 @@ const ResetPasswordPage: React.FC = () => {
           </div>
         </div>
       </div>
+      </LazyMotion>
     );
   }
 
   if (isPasswordReset) {
     return (
+      <LazyMotion features={domAnimation}>
       <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
         <LeftSideImage />
 
@@ -222,10 +225,12 @@ const ResetPasswordPage: React.FC = () => {
           </div>
         </div>
       </div>
+      </LazyMotion>
     );
   }
 
   return (
+    <LazyMotion features={domAnimation}>
     <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
       <LeftSideImage />
 
@@ -339,6 +344,7 @@ const ResetPasswordPage: React.FC = () => {
         </div>
       </div>
     </div>
+    </LazyMotion>
   );
 };
 

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -6,7 +6,7 @@ import loginIllustrationLight from '../assets/images/login-illustration-light.mp
 import loginIllustrationDark from '../assets/images/login-illustration-dark.mp4';
 import loginIllustrationLightPoster from '../assets/images/login-illustration-light-poster.jpg';
 import loginIllustrationDarkPoster from '../assets/images/login-illustration-dark-poster.jpg';
-import { LazyMotion, domAnimation, m } from 'framer-motion';
+import { m } from 'framer-motion';
 
 const LeftSideImage: React.FC = () => (
   <div className="hidden lg:flex lg:w-1/2 relative bg-indigo-600 dark:bg-indigo-900 overflow-hidden">
@@ -173,8 +173,7 @@ const ResetPasswordPage: React.FC = () => {
   // Show loading screen while validating session
   if (isValidatingSession) {
     return (
-      <LazyMotion features={domAnimation}>
-      <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
+            <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
         <LeftSideImage />
 
         <div className="w-full lg:w-1/2 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 overflow-y-auto">
@@ -192,14 +191,12 @@ const ResetPasswordPage: React.FC = () => {
           </div>
         </div>
       </div>
-      </LazyMotion>
     );
   }
 
   if (isPasswordReset) {
     return (
-      <LazyMotion features={domAnimation}>
-      <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
+            <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
         <LeftSideImage />
 
         <div className="w-full lg:w-1/2 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 overflow-y-auto">
@@ -226,13 +223,11 @@ const ResetPasswordPage: React.FC = () => {
           </div>
         </div>
       </div>
-      </LazyMotion>
     );
   }
 
   return (
-    <LazyMotion features={domAnimation}>
-    <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
+        <div className="min-h-screen flex bg-gradient-to-br from-indigo-50 via-purple-50 to-blue-100 dark:from-gray-900 dark:via-indigo-900 dark:to-blue-900 overflow-hidden">
       <LeftSideImage />
 
       <div className="w-full lg:w-1/2 flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 overflow-y-auto">
@@ -345,8 +340,8 @@ const ResetPasswordPage: React.FC = () => {
         </div>
       </div>
     </div>
-    </LazyMotion>
   );
 };
 
 export default ResetPasswordPage;
+

--- a/src/test/components/ui/HoverBorderGradient.test.tsx
+++ b/src/test/components/ui/HoverBorderGradient.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 // Mock framer-motion to avoid animation issues in tests
 vi.mock('framer-motion', () => ({
   LazyMotion: ({ children }: any) => <>{children}</>,
-  domAnimation: {},
+  domAnimation: { type: 'domAnimation' },
   m: {
     div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   },

--- a/src/test/components/ui/HoverBorderGradient.test.tsx
+++ b/src/test/components/ui/HoverBorderGradient.test.tsx
@@ -5,7 +5,9 @@ import React from 'react';
 
 // Mock framer-motion to avoid animation issues in tests
 vi.mock('framer-motion', () => ({
-  motion: {
+  LazyMotion: ({ children }: any) => <>{children}</>,
+  domAnimation: {},
+  m: {
     div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
   },
   AnimatePresence: ({ children }: any) => <>{children}</>,


### PR DESCRIPTION
## Summary
- replace `motion` imports with `LazyMotion`, `domAnimation`, and `m`
- wrap animated sections with `<LazyMotion features={domAnimation}>`
- update framer-motion test mocks to support `LazyMotion` + `m`

## Why
React Doctor recommended using `m` with `LazyMotion` to reduce framer-motion bundle cost.

## Validation
- `npx -y react-doctor@latest` (the `motion` import recommendation is resolved)
- `npm test` (pre-commit hooks)
- `npm run build`
