### PR TITLE
[TM-078] Bugfix: Restore TaskDescription in TaskItem and fix truncation issues

### DIFF
--- a/src/components/TaskDescription.tsx
+++ b/src/components/TaskDescription.tsx
@@ -17,11 +17,16 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, 
 
   const maxLength = 80;
   const isLong = task.description.length > maxLength;
+  const baseClasses = `${className} ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} line-clamp-2`;
 
   if (isLong) {
-    const truncated = task.description.substring(0, maxLength);
+    const descriptionPrefix = task.description.substring(0, maxLength);
+    const lastSpaceIndex = descriptionPrefix.lastIndexOf(' ');
+    const cutIndex = lastSpaceIndex > 0 ? lastSpaceIndex : maxLength;
+    const truncated = task.description.substring(0, cutIndex) + '...';
+    
     return (
-      <p className={`${className} ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'}`}>
+      <p className={baseClasses}>
         {truncated}
         <button
           onClick={(e) => {
@@ -37,7 +42,7 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, 
   }
 
   return (
-    <p className={`${className} ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} line-clamp-2`}>
+    <p className={baseClasses}>
       {task.description}
     </p>
   );

--- a/src/components/TaskDescription.tsx
+++ b/src/components/TaskDescription.tsx
@@ -7,43 +7,48 @@ interface TaskDescriptionProps {
   task: Task;
   onEdit: (task: Task) => void;
   className?: string; // Container classes
+  lines?: number;
 }
 
-export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, className = '' }) => {
+export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, className = '', lines = 2 }) => {
   const { theme } = useTheme();
   const { t } = useTranslation();
 
-  if (!task.description) return null;
+  const text = (task.description ?? '').trim();
+  if (!text) return null;
 
   const maxLength = 80;
-  const isLong = task.description.length > maxLength;
-  const baseClasses = `${className} ${theme === 'dark' ? 'text-gray-300' : 'text-gray-600'} line-clamp-2`;
+  const isLong = text.length > maxLength;
+  
+  const textColorClass = theme === 'dark' ? 'text-gray-400' : 'text-gray-500';
+  const clampClass = `line-clamp-${lines}`;
+  const baseClasses = `${className} ${textColorClass}`;
 
   if (isLong) {
-    const descriptionPrefix = task.description.substring(0, maxLength);
+    const descriptionPrefix = text.substring(0, maxLength);
     const lastSpaceIndex = descriptionPrefix.lastIndexOf(' ');
     const cutIndex = lastSpaceIndex > 0 ? lastSpaceIndex : maxLength;
-    const truncated = task.description.substring(0, cutIndex) + '...';
+    const truncated = text.substring(0, cutIndex) + '...';
     
     return (
-      <p className={baseClasses}>
-        {truncated}
+      <div className={baseClasses}>
+        <span>{truncated}</span>
         <button
           onClick={(e) => {
             e.stopPropagation();
             onEdit(task);
           }}
-          className={`${theme === 'dark' ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-800'} font-medium ml-1 transition-colors duration-200`}
+          className={`${theme === 'dark' ? 'text-indigo-400 hover:text-indigo-300' : 'text-indigo-600 hover:text-indigo-800'} font-medium ml-1 transition-colors duration-200 inline`}
         >
           {t('tasks.see_more')}
         </button>
-      </p>
+      </div>
     );
   }
 
   return (
-    <p className={baseClasses}>
-      {task.description}
-    </p>
+    <div className={`${baseClasses} ${clampClass}`}>
+      {text}
+    </div>
   );
 };

--- a/src/components/TaskDescription.tsx
+++ b/src/components/TaskDescription.tsx
@@ -7,8 +7,14 @@ interface TaskDescriptionProps {
   task: Task;
   onEdit: (task: Task) => void;
   className?: string; // Container classes
-  lines?: number;
+  lines?: 1 | 2 | 3;
 }
+
+const lineClampClasses = {
+  1: 'line-clamp-1',
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+};
 
 export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, className = '', lines = 2 }) => {
   const { theme } = useTheme();
@@ -21,19 +27,21 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, 
   const isLong = text.length > maxLength;
   
   const textColorClass = theme === 'dark' ? 'text-gray-400' : 'text-gray-500';
-  const clampClass = `line-clamp-${lines}`;
+  const clampClass = lineClampClasses[lines];
   const baseClasses = `${className} ${textColorClass}`;
 
   if (isLong) {
-    const descriptionPrefix = text.substring(0, maxLength);
+    const displayMax = maxLength - 3;
+    const descriptionPrefix = text.substring(0, displayMax);
     const lastSpaceIndex = descriptionPrefix.lastIndexOf(' ');
-    const cutIndex = lastSpaceIndex > 0 ? lastSpaceIndex : maxLength;
+    const cutIndex = lastSpaceIndex > 0 ? lastSpaceIndex : displayMax;
     const truncated = text.substring(0, cutIndex) + '...';
     
     return (
-      <div className={baseClasses}>
+      <div role="paragraph" className={baseClasses}>
         <span>{truncated}</span>
         <button
+          type="button"
           onClick={(e) => {
             e.stopPropagation();
             onEdit(task);
@@ -47,8 +55,8 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, 
   }
 
   return (
-    <div className={`${baseClasses} ${clampClass}`}>
+    <p className={`${baseClasses} ${clampClass}`}>
       {text}
-    </div>
+    </p>
   );
 };

--- a/src/components/TaskDescription.tsx
+++ b/src/components/TaskDescription.tsx
@@ -38,7 +38,7 @@ export const TaskDescription: React.FC<TaskDescriptionProps> = ({ task, onEdit, 
     const truncated = text.substring(0, cutIndex) + '...';
     
     return (
-      <div role="paragraph" className={baseClasses}>
+      <div className={`${baseClasses} ${clampClass}`}>
         <span>{truncated}</span>
         <button
           type="button"

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -7,6 +7,7 @@ import { TaskTimer } from './TaskTimer';
 import { useTheme } from '../contexts/ThemeContext';
 import { DeleteConfirmationModal } from './DeleteConfirmationModal';
 import { TruncatedTaskTitle } from './ui/TruncatedTaskTitle';
+import { TaskDescription } from './TaskDescription';
 
 interface TaskItemProps {
   task: Task;
@@ -210,14 +211,11 @@ export const TaskItem: React.FC<TaskItemProps> = ({
             </div>
 
             {/* Description Snippet */}
-            {task.description && (
-              <p className={`
-              text-[11px] sm:text-xs line-clamp-1 ml-6
-              ${theme === 'dark' ? 'text-gray-400' : 'text-gray-500'}
-            `}>
-                {task.description}
-              </p>
-            )}
+            <TaskDescription 
+              task={task} 
+              onEdit={onEdit} 
+              className="mt-1 text-[11px] sm:text-xs ml-6" 
+            />
           </div>
         </div>
 

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -211,11 +211,14 @@ export const TaskItem: React.FC<TaskItemProps> = ({
             </div>
 
             {/* Description Snippet */}
-            <TaskDescription 
-              task={task} 
-              onEdit={onEdit} 
-              className="mt-1 text-[11px] sm:text-xs ml-6" 
-            />
+            {task.description && (
+              <TaskDescription 
+                task={task} 
+                onEdit={onEdit} 
+                className="mt-1 text-[11px] sm:text-xs ml-6" 
+                lines={1}
+              />
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## 📋 Descripción
Atiende el feedback del code review sobre el componente `TaskDescription` y su uso en `TaskItem.tsx`.

### Cambios realizados:
- **P1:** Se restauró la funcionalidad de descripción en `TaskItem.tsx` importando e incluyendo el componente `<TaskDescription />` que se había eliminado en el refactor anterior.
- **P2:** Se estandarizó la clase CSS `line-clamp-2` para ambos casos (reducido y truncado) en `TaskDescription.tsx` para evitar inconsistencias visuales en el layout y aplicar el espaciado adecuado a las tarjetas.
- **P2/P3:** Se añadió lógica para truncar palabras de forma más precisa buscando el último espacio en lugar del carácter rígido 80, y se adjuntó `...` a fin de notificar el truncado corto visible.

## 🎯 Tipo de Cambio
- [x] Bug fix (corrección que soluciona un problema)

## 🧪 Pruebas
- [x] Las pruebas locales existentes (`vitest`) pasan correctamente con las nuevas modificaciones.