### PR TITLE
test: fix react-doctor rules-of-hooks warning in ResetPasswordPage mock

### DIFF
--- a/src/test/pages/ResetPasswordPage.test.tsx
+++ b/src/test/pages/ResetPasswordPage.test.tsx
@@ -28,8 +28,7 @@ vi.mock('../../pages/ResetPasswordPage', () => {
   const React = require('react');
   const { useState } = React;
   
-  return {
-    default: () => {
+  const MockResetPasswordPage = () => {
       const [password, setPassword] = useState('');
       const [confirmPassword, setConfirmPassword] = useState('');
       const [isLoading, setIsLoading] = useState(false);
@@ -262,7 +261,10 @@ vi.mock('../../pages/ResetPasswordPage', () => {
           ])
         )
       ]);
-    }
+  };
+
+  return {
+    default: MockResetPasswordPage,
   };
 });
 


### PR DESCRIPTION
﻿## Summary
- Replace anonymous default mock component in `ResetPasswordPage.test.tsx` with a named React component (`MockResetPasswordPage`).
- This resolves React Doctor `rules-of-hooks` errors where `useState` was flagged inside an anonymous non-component function.

## Why
React hooks must run inside React components or custom hooks. The previous inline anonymous default export in the mock caused hook linting tools to classify it as an invalid context.

## Validation
- `npx -y react-doctor@latest --yes --project kolium --fail-on error` ✅
- `npm test -- src/test/pages/ResetPasswordPage.test.tsx` ✅

## Notes
- No runtime behavior change.
- Test-only refactor for hook-rule compliance.
