### PR TITLE
fix(ui): hide non-numeric task ids

### DIFF
--- a/e2e/task-id-visibility.spec.ts
+++ b/e2e/task-id-visibility.spec.ts
@@ -1,16 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { AppPage } from './page-objects/app.page';
-import { TaskPage } from './page-objects/task.page';
 import { BoardPage } from './page-objects/board.page';
 
 test.describe('Task ID visibility', () => {
   let appPage: AppPage;
-  let taskPage: TaskPage;
   let boardPage: BoardPage;
 
   test.beforeEach(async ({ page }) => {
     appPage = new AppPage(page);
-    taskPage = new TaskPage(page);
     boardPage = new BoardPage(page);
 
     await appPage.goto();
@@ -20,24 +17,38 @@ test.describe('Task ID visibility', () => {
     await appPage.page.reload();
   });
 
-  test('should show a #ID in board cards and in task detail modal header', async ({ page }) => {
+  test('should show a numeric #ID in board cards and in task detail modal header', async ({ page }) => {
     const title = 'Task With Visible ID';
 
-    await appPage.openAddTaskModal();
-    await taskPage.createTask({ title });
+    await page.evaluate(({ title }) => {
+      localStorage.setItem('taskflow_tasks', JSON.stringify([{
+        id: '2781',
+        title,
+        description: '',
+        status: 'Open',
+        createdAt: new Date().toISOString(),
+        childIds: [],
+        depth: 0,
+        timeTracking: {
+          totalTimeSpent: 0,
+          isActive: false,
+          timeEntries: []
+        }
+      }]));
+    }, { title });
+    await page.reload();
 
-    await appPage.switchToView('board');
     const card = boardPage.getTaskCard(title);
 
     // Board card should show a mono badge starting with '#'
-    const idBadge = card.locator('span.font-mono').first();
+    const idBadge = card.getByTestId('task-id-badge');
     await expect(idBadge).toBeVisible();
-    await expect(idBadge).toHaveText(/^#.+/);
+    await expect(idBadge).toHaveText('#2781');
 
     // Open modal and validate header contains same ID
     await card.click();
 
-    const modalHeaderBadge = page.locator('[role="dialog"] h2 span.font-mono').first();
+    const modalHeaderBadge = page.locator('[role="dialog"] h2 [data-testid="task-id-badge"]');
     await expect(modalHeaderBadge).toBeVisible();
     await expect(modalHeaderBadge).toHaveText(/^#.+/);
 
@@ -47,5 +58,32 @@ test.describe('Task ID visibility', () => {
     expect(boardId).toBeTruthy();
     expect(modalId).toBeTruthy();
     expect(modalId).toBe(boardId);
+  });
+
+  test('should not render a long temporary id from local storage', async ({ page }) => {
+    const title = 'Task With Temporary ID';
+
+    await page.evaluate(({ title }) => {
+      localStorage.setItem('taskflow_tasks', JSON.stringify([{
+        id: 'ms7xgti5lgqk5g1vn5',
+        title,
+        description: '',
+        status: 'Open',
+        createdAt: new Date().toISOString(),
+        childIds: [],
+        depth: 0,
+        timeTracking: {
+          totalTimeSpent: 0,
+          isActive: false,
+          timeEntries: []
+        }
+      }]));
+    }, { title });
+    await page.reload();
+
+    const card = boardPage.getTaskCard(title);
+    await expect(card).toBeVisible();
+    await expect(card.getByTestId('task-id-badge')).toHaveCount(0);
+    await expect(page.getByText('#ms7xgti5lgqk5g1vn5')).toHaveCount(0);
   });
 });

--- a/src/components/ui/TaskIdBadge.tsx
+++ b/src/components/ui/TaskIdBadge.tsx
@@ -18,6 +18,9 @@ export const TaskIdBadge: React.FC<TaskIdBadgeProps> = ({
 
   if (id === undefined || id === null) return null;
 
+  const normalizedId = String(id).trim();
+  if (!/^\d+$/.test(normalizedId)) return null;
+
   const sizeClasses = {
     xs: 'text-xs scale-90 origin-left',
     sm: 'text-xs',
@@ -29,10 +32,11 @@ export const TaskIdBadge: React.FC<TaskIdBadgeProps> = ({
 
   return (
     <span 
+      data-testid="task-id-badge"
       className={`font-mono mr-2 ${sizeClasses[size]} ${opacityClass} truncate ${maxWidth} ${className}`}
-      title={String(id)}
+      title={normalizedId}
     >
-      #{id}
+      #{normalizedId}
     </span>
   );
 };

--- a/src/test/components/ui/TaskIdBadge.test.tsx
+++ b/src/test/components/ui/TaskIdBadge.test.tsx
@@ -22,6 +22,16 @@ describe('TaskIdBadge', () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it('does not render temporary non-numeric ids', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <TaskIdBadge id="ms7xgti5lgqk5g1vn5" />
+      </ThemeProvider>
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
   it('applies correct size classes', () => {
     const { container: xsContainer } = render(
       <ThemeProvider>


### PR DESCRIPTION
## Summary\n- render task badges only when the ID contains digits\n- add a stable task-id-badge selector for UI verification\n- cover numeric and temporary alphanumeric IDs in unit and E2E tests\n\n## Validation\n- npm test: 52 files, 386 tests passed\n- npm run build: passed\n- npx playwright test e2e/task-id-visibility.spec.ts: 2 passed\n\nCloses the inconsistent task ID rendering shown in the UI.