### PR TITLE
fix(components): keep settings tab visible

### DIFF
--- a/e2e/account-settings.spec.ts
+++ b/e2e/account-settings.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 import { AuthPage } from './page-objects/auth.page';
 
 test.describe('Account settings personal access tokens', () => {
+  test.use({ viewport: { width: 1280, height: 600 } });
+
   test('creates and revokes a token from the Settings tab', async ({ page }) => {
     const email = process.env.E2E_USER_PROFILE_EMAIL;
     const password = process.env.E2E_USER_PROFILE_PASSWORD;
@@ -63,7 +65,11 @@ test.describe('Account settings personal access tokens', () => {
 
     await page.locator('[data-testid="account-menu-button"]:visible').first().click();
     await page.getByTestId('my-profile-menu-item').click();
-    await page.getByTestId('settings-tab').click();
+    const settingsTab = page.getByTestId('settings-tab');
+    await expect(settingsTab).toBeVisible();
+    await expect(settingsTab).toBeInViewport();
+    await settingsTab.click();
+    await expect(settingsTab).toHaveAttribute('aria-selected', 'true');
     await expect(page.getByTestId('account-settings-panel')).toBeVisible();
 
     await page.getByLabel('Token name').fill('Playwright MCP');

--- a/src/components/features/account/MyProfileModal.tsx
+++ b/src/components/features/account/MyProfileModal.tsx
@@ -135,13 +135,13 @@ export const MyProfileModal: React.FC<MyProfileModalProps> = ({
     return (
         <>
             <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-                <DialogContent data-testid="my-profile-modal" className={`sm:max-w-xl p-0 overflow-hidden rounded-2xl border ${theme === 'dark' ? 'bg-gray-900 border-gray-800' : 'bg-white'}`}>
+                <DialogContent data-testid="my-profile-modal" className={`sm:max-w-xl max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden !top-4 !translate-y-0 md:!top-[50%] md:!translate-y-[-50%] p-0 rounded-2xl border ${theme === 'dark' ? 'bg-gray-900 border-gray-800' : 'bg-white'}`}>
                     <DialogHeader className="sr-only">
                         <DialogTitle>My Profile</DialogTitle>
                         <DialogDescription>Edit your profile information and settings</DialogDescription>
                     </DialogHeader>
 
-                    <div className={`flex gap-1 border-b px-6 pt-4 ${theme === 'dark' ? 'border-gray-800' : 'border-gray-200'}`} role="tablist" aria-label={t('account.my_account')}>
+                    <div className={`sticky top-0 z-20 flex gap-1 border-b px-6 pt-4 ${theme === 'dark' ? 'border-gray-800 bg-gray-900' : 'border-gray-200 bg-white'}`} role="tablist" aria-label={t('account.my_account')}>
                         <button
                             type="button"
                             role="tab"


### PR DESCRIPTION
## Summary
- Keep the My Profile modal within the viewport on short screens.
- Keep the profile/settings tabs visible while scrolling.
- Extend the Playwright E2E flow to assert Settings is in the viewport before selecting it.

## Verification
- Playwright: e2e/account-settings.spec.ts (1 passed)
- Vitest: 52 files, 385 tests passed
- npm run build passed